### PR TITLE
docs: reset semver identifiers below 0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Agentic Delivery Framework brings together two collaborating roles:
 
 ## Spec & Conformance
 
-- [ADF Specification v0.2.0](docs/specs/spec.v0.2.0.md)
+- [ADF Specification v0.0.20](docs/specs/spec.v0.0.20.md)
 - [Conformance Levels (L1–L3)](docs/CONFORMANCE.md)
 
 ## Platform Profiles
@@ -66,7 +66,7 @@ Program Director (outer loop) orchestrates Iterations and workspace runtimes; th
 - `docs/problem-statement.md` – challenges with waterfall agents, unsafe local writes, and vendor lock-in.
 - `docs/goals.md` – measurable methodology goals and guardrails.
 - `docs/roadmap.md` – evolution of conformance, governance, and profile support.
-- `docs/specs/spec.v0.2.0.md` – semver-tracked specification for orchestration and Delivery Team loop.
+- `docs/specs/spec.v0.0.20.md` – semver-tracked specification for orchestration and Delivery Team loop.
 - `docs/specs/CHANGELOG.md` – release notes for specification revisions.
 - `docs/CONFORMANCE.md` – normative conformance levels (L1–L3).
 - `docs/PROFILES.md` – platform profiles and mappings to neutral terminology.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ The Agentic Delivery Framework (ADF) is a vendor-neutral methodology. Contributi
 
 ## Before You Start
 
-- Review the [Governance](GOVERNANCE.md) model and the latest [Specification](specs/spec.v0.2.0.md).
+- Review the [Governance](GOVERNANCE.md) model and the latest [Specification](specs/spec.v0.0.20.md).
 - Check open RFCs in [docs/RFCs](RFCs/README.md) to avoid duplicating proposals.
 - Align proposed terminology with the neutral glossary in [AGENTS.md](../AGENTS.md).
 

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -4,7 +4,7 @@ The Agentic Delivery Framework (ADF) specification is vendor-neutral. Platform p
 
 ## Using Profiles
 
-1. Implement the neutral methodology by following the [ADF Specification](specs/spec.v0.2.0.md) and [Conformance Levels](CONFORMANCE.md).
+1. Implement the neutral methodology by following the [ADF Specification](specs/spec.v0.0.20.md) and [Conformance Levels](CONFORMANCE.md).
 2. Select a platform profile to understand how Iterations, workspace runtimes, and change request gates map to specific products.
 3. Extend or author new profiles as your organization adopts additional platforms.
 

--- a/docs/adrs/0001-architecture-dual-loop.md
+++ b/docs/adrs/0001-architecture-dual-loop.md
@@ -1,6 +1,6 @@
 # ADR 0001: Dual-Loop Architecture (Program Director + Delivery Team)
 
-> Status: Accepted — superseded terms retained historically; see spec v0.2.0 for neutral nomenclature.
+> Status: Accepted — superseded terms retained historically; see spec v0.0.20 for neutral nomenclature.
 > Also Known As: formerly Agentic-Agile dual-loop (Outer Orchestrator / Inner Dev Agents).
 
 ## Context

--- a/docs/adrs/0002-adopt-enterprise-naming-adf.md
+++ b/docs/adrs/0002-adopt-enterprise-naming-adf.md
@@ -30,7 +30,7 @@ Adopt the **Agentic Delivery Framework (ADF)** naming set:
 
 - Aligns with enterprise language for program/delivery management.
 - Matches GitHub-native concepts (Projects Iterations, PR governance).
-- Keeps the spec behavior unchanged—semver patch (v0.1.1) captures naming-only update.
+- Keeps the spec behavior unchanged—semver patch (v0.0.11) captures naming-only update.
 - Provides glossary consistency across README, AGENTS, docs, prompts, and specs.
 
 ## Consequences

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -1,13 +1,13 @@
 # Goals (MVP → Near-term)
 
-## MVP (v0.1.x)
+## MVP (v0.0.1x)
 - ✅ Two-loop architecture documented and reproducible.
 - ✅ Program Director can **create/reuse/stop** a workspace runtime and **start** the Delivery Team.
 - ✅ Delivery Team works on a single work item, opens a change request with “Closes <work-item>”.
 - ✅ Change request gates: branch protection + required checks + automated review + human review.
 - ✅ Secrets stored in managed vaults; **no unmanaged local execution**.
 
-## Near-term (v0.2.x)
+## Near-term (v0.0.2x)
 - 🔶 Work management Iterations drive cadence automatically.
 - 🔶 Warm-start images enabled; < 5 minutes cold-start target for workspace runtimes.
 - 🔶 Story templates with acceptance criteria and test stubs.

--- a/docs/prompts/initial_agent_prompt.md
+++ b/docs/prompts/initial_agent_prompt.md
@@ -16,7 +16,7 @@ Create/refresh the repo’s documentation and ADF scaffolding so that the **Prog
    - `/docs/problem-statement.md`
    - `/docs/goals.md`
    - `/docs/roadmap.md`
-   - `/docs/specs/spec.v0.1.3.md` (semver spec)
+   - `/docs/specs/spec.v0.0.13.md` (semver spec)
    - `/docs/adrs/0001-architecture-dual-loop.md`
    - `/docs/naming/enterprise-friendly-naming.md`
 2. Add GitHub hygiene if missing:

--- a/docs/specs/CHANGELOG.md
+++ b/docs/specs/CHANGELOG.md
@@ -1,11 +1,11 @@
 # ADF Specification Changelog
 
-## v0.2.0 — 2025-10-04
+## v0.0.20 — 2025-10-04
 - Methodology refactor: neutral terminology, platform profiles, and conformance references.
-- No normative behavior change relative to v0.1.3.
+- No normative behavior change relative to v0.0.13.
 
-## v0.1.3 — 2024-??-??
+## v0.0.13 — 2024-??-??
 - Docs-only update reflecting repository rename and GitHub-focused terminology (historical).
 
-## v0.1.2 and earlier
-- See respective spec files (`spec.v0.1.x.md`) for historical GitHub-centric framing.
+## v0.0.12 and earlier
+- See respective spec files (`spec.v0.0.10.md` through `spec.v0.0.13.md`) for historical GitHub-centric framing.

--- a/docs/specs/spec.v0.0.10.md
+++ b/docs/specs/spec.v0.0.10.md
@@ -1,29 +1,29 @@
-# Spec v0.1.1 — MVP (naming update)
+# Spec v0.0.10 — MVP
 
 ## 1. Architecture
-- **Program Director** (service or GitHub App) manages Iterations and Codespaces lifecycle.
-- **Delivery Team** runs **inside Codespaces**; supports Aider/Cline/Continue/OpenHands.
+- **Outer Orchestrator** (service or GitHub App) manages sprints and Codespaces lifecycle.
+- **Inner Agent** runs **inside Codespaces**; supports Aider/Cline/Continue/OpenHands.
 
 ## 2. Required Capabilities
-### Program Director
-- **Select work**: read Issues with label `iteration:<num>` or in active **Iteration**.
+### Outer Orchestrator
+- **Select work**: read Issues with label `sprint:<num>` or in active **Iteration**.
 - **Codespaces lifecycle**: create/reuse/stop via REST or `gh codespace`.
-- **Start Delivery Team**: `gh codespace ssh -c 'git switch -c feat/<issue>; ./agent/start.sh <issue>'`.
+- **Start inner agent**: `gh codespace ssh -c 'git switch -c feat/<issue>; ./agent/start.sh <issue>'`.
 - **Governance**: ensure Branch Protection enabled, required checks configured, and Copilot Code Review assigned.
 - **Secrets**: provision Codespaces Secrets for tokens/keys; never log secrets.
 
-### Delivery Team
+### Inner Agent
 - **Environment**: devcontainer includes git, Node/PNPM (or your stack), Docker‑in‑Docker, optional Supabase CLI.
 - **Behavior**: create `feat/*` branch, implement ACs, run tests/linters, open PR with `Closes #<id>`; iterate until green.
 
 ## 3. Devcontainer (baseline)
 - Base image: Debian/Ubuntu devcontainer with git + gh + Node LTS + Docker‑in‑Docker feature.
 - Ports default **Private**; expose only what’s needed.
-- Install chosen Delivery Team tooling (Aider/Cline/Continue/OpenHands) and `./agent/start.sh`.
+- Install chosen inner agent (Aider/Cline/Continue/OpenHands) and `./agent/start.sh`.
 
 ## 4. Governance
 - Branch Protection on default branch; required checks (CI, lint, tests, CodeQL).
 - Copilot Code Review auto‑requested.
 
 ## 5. Acceptance
-- From a clean repo, Program Director can: pick one Issue, spin a Codespace, start the Delivery Team, get a PR, pass checks, merge, close Issue, stop Codespace.
+- From a clean repo, orchestrator can: pick one Issue, spin a Codespace, start inner agent, get a PR, pass checks, merge, close Issue, stop Codespace.

--- a/docs/specs/spec.v0.0.11.md
+++ b/docs/specs/spec.v0.0.11.md
@@ -1,29 +1,29 @@
-# Spec v0.1.0 — MVP
+# Spec v0.0.11 — MVP (naming update)
 
 ## 1. Architecture
-- **Outer Orchestrator** (service or GitHub App) manages sprints and Codespaces lifecycle.
-- **Inner Agent** runs **inside Codespaces**; supports Aider/Cline/Continue/OpenHands.
+- **Program Director** (service or GitHub App) manages Iterations and Codespaces lifecycle.
+- **Delivery Team** runs **inside Codespaces**; supports Aider/Cline/Continue/OpenHands.
 
 ## 2. Required Capabilities
-### Outer Orchestrator
-- **Select work**: read Issues with label `sprint:<num>` or in active **Iteration**.
+### Program Director
+- **Select work**: read Issues with label `iteration:<num>` or in active **Iteration**.
 - **Codespaces lifecycle**: create/reuse/stop via REST or `gh codespace`.
-- **Start inner agent**: `gh codespace ssh -c 'git switch -c feat/<issue>; ./agent/start.sh <issue>'`.
+- **Start Delivery Team**: `gh codespace ssh -c 'git switch -c feat/<issue>; ./agent/start.sh <issue>'`.
 - **Governance**: ensure Branch Protection enabled, required checks configured, and Copilot Code Review assigned.
 - **Secrets**: provision Codespaces Secrets for tokens/keys; never log secrets.
 
-### Inner Agent
+### Delivery Team
 - **Environment**: devcontainer includes git, Node/PNPM (or your stack), Docker‑in‑Docker, optional Supabase CLI.
 - **Behavior**: create `feat/*` branch, implement ACs, run tests/linters, open PR with `Closes #<id>`; iterate until green.
 
 ## 3. Devcontainer (baseline)
 - Base image: Debian/Ubuntu devcontainer with git + gh + Node LTS + Docker‑in‑Docker feature.
 - Ports default **Private**; expose only what’s needed.
-- Install chosen inner agent (Aider/Cline/Continue/OpenHands) and `./agent/start.sh`.
+- Install chosen Delivery Team tooling (Aider/Cline/Continue/OpenHands) and `./agent/start.sh`.
 
 ## 4. Governance
 - Branch Protection on default branch; required checks (CI, lint, tests, CodeQL).
 - Copilot Code Review auto‑requested.
 
 ## 5. Acceptance
-- From a clean repo, orchestrator can: pick one Issue, spin a Codespace, start inner agent, get a PR, pass checks, merge, close Issue, stop Codespace.
+- From a clean repo, Program Director can: pick one Issue, spin a Codespace, start the Delivery Team, get a PR, pass checks, merge, close Issue, stop Codespace.

--- a/docs/specs/spec.v0.0.12.md
+++ b/docs/specs/spec.v0.0.12.md
@@ -1,4 +1,4 @@
-# Spec v0.1.2 — MVP (documentation enhancements)
+# Spec v0.0.12 — MVP (documentation enhancements)
 
 ## 1. Architecture
 - **Program Director** (service or GitHub App) manages Iterations and Codespaces lifecycle.

--- a/docs/specs/spec.v0.0.13.md
+++ b/docs/specs/spec.v0.0.13.md
@@ -1,4 +1,4 @@
-# Spec v0.1.3 — MVP (docs-only repo rename)
+# Spec v0.0.13 — MVP (docs-only repo rename)
 
 ## Changelog
 

--- a/docs/specs/spec.v0.0.20.md
+++ b/docs/specs/spec.v0.0.20.md
@@ -1,8 +1,8 @@
-# Spec v0.2.0 — Methodology Terminology Refactor
+# Spec v0.0.20 — Methodology Terminology Refactor
 
 ## Changelog
 
-- Structural/terminology update: reframed ADF as a vendor-neutral methodology with platform profiles. No behavioral change relative to v0.1.3.
+- Structural/terminology update: reframed ADF as a vendor-neutral methodology with platform profiles. No behavioral change relative to v0.0.13.
 - Introduced references to [Conformance Levels](../CONFORMANCE.md) and [Platform Profiles](../PROFILES.md).
 
 ## 1. Architecture
@@ -40,5 +40,5 @@
 - **Profiles**: Platform-specific terminology and automation belong in [docs/PROFILES.md](../PROFILES.md) and related files (e.g., [GitHub profile](../profiles/github.md)).
 
 ## 7. References
-- Previous spec versions (v0.1.x) retain GitHub-centric language for historical context.
+- Previous spec versions (v0.0.10–v0.0.13) retain GitHub-centric language for historical context.
 - Companion implementations: see [airnub/adf-github-suite](https://github.com/airnub/adf-github-suite) for an example aligned with the GitHub profile.


### PR DESCRIPTION
## Summary
- rename specification files and headings to use v0.0.10–v0.0.20 numbering
- update documentation references to point to the reset versions across the repo
- refresh changelog, goals, ADRs, and prompts to reflect the new sub-0.1.0 scheme

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e16a74a1bc8324856584e747094a27