### PR TITLE
Fix mermaid diagram syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ See [docs/PROFILES.md](docs/PROFILES.md) and [docs/profiles/github.md](docs/prof
 
 ```mermaid
 flowchart TD
-  PD[Program Director (outer)] --> P1{Select Iteration \n in Work Management System}
+  PD[Program Director (outer)] --> P1{Select Iteration <br/> in Work Management System}
   P1 -->|For each Story| WR{Workspace Runtime available?}
-  WR -->|No| C1[Create Workspace Runtime \n (warm start, secrets, retention)]
+  WR -->|No| C1[Create Workspace Runtime <br/> (warm start, secrets, retention)]
   WR -->|Yes| C2[Resume Workspace Runtime]
   C1 --> DT[Start Delivery Team inside workspace]
   C2 --> DT
   DT --> B1[Branch feat/&lt;work-item&gt;]
-  B1 --> W[Implement Tasks \n plan → edit → run → test]
-  W --> CR[Open Change Request \n with checklists ("Closes &lt;work-item&gt;")]
+  B1 --> W[Implement Tasks <br/> plan → edit → run → test]
+  W --> CR[Open Change Request <br/> with checklists ("Closes &lt;work-item&gt;")]
   CR --> G{{Change Request Gates}}
   G --> G1[CI / Tests]
   G --> G2[QA Verification]
@@ -49,7 +49,7 @@ flowchart TD
   G -->|Fail| DT
   M --> R{More Stories in Iteration?}
   R -->|Yes| P1
-  R -->|No| H[Hibernate/Stop Workspace \n Generate Metrics]
+  R -->|No| H[Hibernate/Stop Workspace <br/> Generate Metrics]
 ```
 
 Program Director (outer loop) orchestrates Iterations and workspace runtimes; the Delivery Team (inner loop) delivers change requests through transparent gates.

--- a/docs/diagrams/adf-overview-flow.mmd
+++ b/docs/diagrams/adf-overview-flow.mmd
@@ -1,23 +1,23 @@
 flowchart TD
   %% Agentic Delivery Framework — Overview Flow
-  A[Program Director\n(Outside Codespaces)] --> B{Select Iteration\nvia GitHub Projects}
+  A[Program Director<br/>(Outside Codespaces)] --> B{Select Iteration<br/>via GitHub Projects}
   B -->|For each Story| C{Codespace exists?}
-  C -->|No| D[Create Codespace\n(prebuilds, secrets, retention)]
+  C -->|No| D[Create Codespace<br/>(prebuilds, secrets, retention)]
   C -->|Yes| E[Resume Codespace]
-  D --> F[Start Delivery Team inside Codespace\n(Aider/Cline/Continue/OpenHands)]
+  D --> F[Start Delivery Team inside Codespace<br/>(Aider/Cline/Continue/OpenHands)]
   E --> F
-  F --> G[Create branch\nfeat/&lt;issue-key&gt;]
-  G --> H[Implement Tasks\nplan → edit → run → test]
-  H --> I[Open PR with checklists\n"Closes #&lt;issue-id&gt;"]
+  F --> G[Create branch<br/>feat/&lt;issue-key&gt;]
+  G --> H[Implement Tasks<br/>plan → edit → run → test]
+  H --> I[Open PR with checklists<br/>"Closes #&lt;issue-id&gt;"]
   I --> J{{PR Gates}}
   J --> J1[CI / Tests]
   J --> J2[QA Verification]
-  J --> J3[Security Review\n(CodeQL / deps)]
+  J --> J3[Security Review<br/>(CodeQL / deps)]
   J --> J4[Copilot Code Review]
   J --> J5[Human Reviewer(s)]
-  J -->|All pass| K[Merge → Close Issue →\nMove Story to Done]
+  J -->|All pass| K[Merge → Close Issue →<br/>Move Story to Done]
   J -->|Fail| F
   K --> L{More Stories in Iteration?}
   L -->|Yes| B
-  L -->|No| M[Stop/Hibernate Codespace\nGenerate Metrics]
-  M --> N[Iteration Review & Retro\nProgram Director plans next Iteration]
+  L -->|No| M[Stop/Hibernate Codespace<br/>Generate Metrics]
+  M --> N[Iteration Review & Retro<br/>Program Director plans next Iteration]

--- a/docs/diagrams/adf-overview-neutral.mmd
+++ b/docs/diagrams/adf-overview-neutral.mmd
@@ -1,14 +1,14 @@
 %% Agentic Delivery Framework — Overview Flow (Neutral)
 flowchart TD
-  PD[Program Director (outer)] --> P1{Select Iteration \n in Work Management System}
+  PD[Program Director (outer)] --> P1{Select Iteration <br/> in Work Management System}
   P1 -->|For each Story| WR{Workspace Runtime available?}
-  WR -->|No| C1[Create Workspace Runtime \n (warm start, secrets, retention)]
+  WR -->|No| C1[Create Workspace Runtime <br/> (warm start, secrets, retention)]
   WR -->|Yes| C2[Resume Workspace Runtime]
   C1 --> DT[Start Delivery Team inside workspace]
   C2 --> DT
   DT --> B1[Branch feat/&lt;work-item&gt;]
-  B1 --> W[Implement Tasks \n plan → edit → run → test]
-  W --> CR[Open Change Request \n with checklists ("Closes &lt;work-item&gt;")]
+  B1 --> W[Implement Tasks <br/> plan → edit → run → test]
+  W --> CR[Open Change Request <br/> with checklists ("Closes &lt;work-item&gt;")]
   CR --> G{{Change Request Gates}}
   G --> G1[CI / Tests]
   G --> G2[QA Verification]
@@ -19,4 +19,4 @@ flowchart TD
   G -->|Fail| DT
   M --> R{More Stories in Iteration?}
   R -->|Yes| P1
-  R -->|No| H[Hibernate/Stop Workspace \n Generate Metrics]
+  R -->|No| H[Hibernate/Stop Workspace <br/> Generate Metrics]

--- a/docs/diagrams/adf-sequence.mmd
+++ b/docs/diagrams/adf-sequence.mmd
@@ -8,7 +8,7 @@ sequenceDiagram
 
   PD->>GH: Select active Iteration & Stories
   PD->>CS: Create/Resume Codespace (prebuilds, secrets)
-  PD->>CS: Start DT via `gh codespace ssh -c`
+  PD->>CS: Start DT via gh codespace ssh -c
   DT->>CS: git switch -c feat/&lt;issue-key&gt;
   DT->>CS: Implement Tasks (edit/run/test)
   DT->>PR: Open PR with "Closes #&lt;issue-id&gt;"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,15 +22,15 @@
 ## Iteration Flow
 ```mermaid
 flowchart TD
-  PD[Program Director (outer)] --> P1{Select Iteration \n in Work Management System}
+  PD[Program Director (outer)] --> P1{Select Iteration <br/> in Work Management System}
   P1 -->|For each Story| WR{Workspace Runtime available?}
-  WR -->|No| C1[Create Workspace Runtime \n (warm start, secrets, retention)]
+  WR -->|No| C1[Create Workspace Runtime <br/> (warm start, secrets, retention)]
   WR -->|Yes| C2[Resume Workspace Runtime]
   C1 --> DT[Start Delivery Team inside workspace]
   C2 --> DT
   DT --> B1[Branch feat/&lt;work-item&gt;]
-  B1 --> W[Implement Tasks \n plan → edit → run → test]
-  W --> CR[Open Change Request \n with checklists ("Closes &lt;work-item&gt;")]
+  B1 --> W[Implement Tasks <br/> plan → edit → run → test]
+  W --> CR[Open Change Request <br/> with checklists ("Closes &lt;work-item&gt;")]
   CR --> G{{Change Request Gates}}
   G --> G1[CI / Tests]
   G --> G2[QA Verification]
@@ -41,7 +41,7 @@ flowchart TD
   G -->|Fail| DT
   M --> R{More Stories in Iteration?}
   R -->|Yes| P1
-  R -->|No| H[Hibernate/Stop Workspace \n Generate Metrics]
+  R -->|No| H[Hibernate/Stop Workspace <br/> Generate Metrics]
 ```
 
 Telemetry and budget controls attach at workspace runtime creation/resume (nodes C1/C2) and at hibernate/stop (node H) so the Program Director can meter spend across Iterations.


### PR DESCRIPTION
## Summary
- replace escaped newline markers in flowchart diagrams with `<br/>` so Mermaid renders multi-line labels
- remove an inline backtick command in the GitHub-specific sequence diagram to keep the syntax valid
- mirror the fixed flowchart syntax in the README and roadmap copies of the diagrams

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e1789092c4832485ee96ade71957b5