### PR TITLE
Remove redundant placeholder documentation files

### DIFF
--- a/docs/goals.md
+++ b/docs/goals.md
@@ -1,7 +1,0 @@
-# Goals (consolidated)
-
-Goals moved to the [Agentic Delivery Framework overview](overview.md#goals).
-
----
-
-This methodology/spec is licensed under CC BY-SA 4.0.

--- a/docs/no-code-policy.md
+++ b/docs/no-code-policy.md
@@ -1,7 +1,0 @@
-# No-code policy (consolidated)
-
-The repository guardrails now live in the [ADF Delivery Handbook](guide/handbook.md#repository-guardrails-no-code-policy).
-
----
-
-This methodology/spec is licensed under CC BY-SA 4.0.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,0 @@
-# Roadmap (consolidated)
-
-The active roadmap is maintained in the [Agentic Delivery Framework overview](overview.md#roadmap).
-
----
-
-This methodology/spec is licensed under CC BY-SA 4.0.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,7 +1,0 @@
-# Vision (consolidated)
-
-This content now lives in the [Agentic Delivery Framework overview](overview.md#vision).
-
----
-
-This methodology/spec is licensed under CC BY-SA 4.0.


### PR DESCRIPTION
## Summary
- remove the placeholder goals, vision, roadmap, and no-code policy docs that only linked to consolidated content

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1c2cee08c8324b8b1038fc344dbde