### PR TITLE
feat: align docs site with scrum-first onboarding

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,3 @@
+# CHANGELOG (Informative)
+
+This page mirrors the repository [CHANGELOG](../CHANGELOG.md). Refer to the root file for authoritative release notes.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,40 @@
+# Frequently Asked Questions (Informative)
+
+**Is ADF more complex than Scrum?**  
+No. Scrum roles, events, and artifacts remain intact. ADF adds guardrails (CR-First, SSP, Delivery Pulse) without new ceremonies. See the [Agile/Scrum map](overview/agile-scrum-map.md).
+
+**Do we need extra meetings?**  
+No. The Delivery Pulse replaces the Daily Scrum with a ≤10 minute evidence review anchored on the Pulse Increment.
+
+**Can we adopt ADF without AI agents today?**  
+Yes. The framework is platform neutral and improves human-only teams while preparing for AI contributors.
+
+**What is “CR-First”?**  
+Every change flows through one Change Request that must pass the normative gates defined in the [Specification](specs/adf-spec-v0.5.0.md#change-request-gates).
+
+**How do Story Previews fit with Sprint Reviews?**  
+Story Preview happens before merge, giving the Product Owner confidence that Sprint Review demos will succeed. Sprint Review remains a Sprint-level inspection.
+
+**Does Delivery Pulse replace Sprint Review?**  
+No. Delivery Pulse is a daily checkpoint. Sprint Review stays as the formal end-of-Sprint inspection.
+
+**What evidence do we archive?**  
+At minimum keep the Evidence Bundle (`requirements-trace.json`), gate outputs, and Delivery Pulse notes. Details live in the [Handbook Evidence chapter](handbook/evidence-bundle.md).
+
+**How do we involve security or compliance?**  
+Use the conformance ladder in the [Adoption Guide](overview/adoption-guide.md). L2/L3 introduce security-static, deps-supply-chain, and compliance gates without changing Scrum cadences.
+
+**Will agents break our Definition of Done?**  
+No. ADF requires that agents follow the same DoD enforced by CR gates, Story Preview, and human approval when needed.
+
+**What happens if a gate fails?**  
+Treat it like any failing check: resolve inside the CR before merge. The Delivery Lead monitors status during Delivery Pulse.
+
+**Can we run multiple Stories in parallel?**  
+Yes, but keep SSP constraints: one Story per branch with exclusive lease. Use WIP limits to prevent overload.
+
+**How fast can we reach L1?**  
+Most teams complete L1 in a day using the [Quickstart](overview/quickstart-l1.md). It focuses on PR templates, minimum gates, and the first Delivery Pulse.
+
+**Where do we log audits?**  
+Store audit reports under `docs/audits/` using the provided template. Reference them in the [Audits sidebar](audits/README.md).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,18 +1,17 @@
-# ADF Glossary (Neutral)
+# ADF Glossary (Informative)
 
 | Term | Definition |
 | --- | --- |
-| **Delivery Lead** | Accountability that steers planning & delivery flow outside the workspace runtime; facilitates Sprint events, enforces CR-first policy, manages WIP limits, and upholds DoD + gate evidence. |
-| **Product Owner** | Accountability that maintains the Product Goal and Product Backlog, clarifies acceptance criteria, and accepts outcomes during Story Preview and Sprint Review. |
-| **Developers** | Accountability that plans, builds, tests, and documents increments inside the governed workspace runtime (Humans / AI / Hybrid pairs). |
-| **Sprint (aka Iteration)** | Timebox for planning, Delivery Pulse, Sprint Review, and Sprint Retrospective anchored around one Sprint Goal. |
-| **Change Request (CR)** | Platform-specific merge request (PR/MR/CL) used to deliver changes. Must pass DoD + gate evidence before merge. |
-| **Definition of Done (DoD)** | Shared checklist that defines quality, documentation, and verification standards for an Increment. |
-| **Story Preview** | Per-story demo artifact (preview environment or local recipe) with evidence before a Story is marked Done. Lives in the Change Request. |
-| **Pulse Increment** | Daily demo build aggregating all merged, green work; reviewed during the Delivery Pulse. |
-| **Delivery Pulse** | Daily cadence combining an automated overnight pulse and a 10–15 minute human sync to inspect Pulse Increment evidence, WIP, and next steps. |
-| **CR Gates** | Required checks on a Change Request (CI/tests, QA, security, automated review, human approval, Performance Budget). |
-| **Performance Budget** | Agreed thresholds for latency, throughput, or resource use that changes MUST respect when touching performance-sensitive paths. |
-| **WIP Limits** | Policies that cap in-progress Stories or tasks (e.g., ≤3 active Stories per team/agent) to preserve flow. |
-| **Exclusive Lease** | Time-bounded control granting exactly one worker (human or agent) the ability to push to a Story branch during SSP execution. |
-| **Subtask Sequencing Policy (SSP)** | Normative practice that runs decomposed sub-tasks sequentially on a single Story branch with exclusive lease control, per-sub-task Story Preview checkpoints, and a single Change Request at completion. |
+| **Change Request (CR)** | Platform-specific merge request (PR/MR/CL) that must satisfy all required gates before merge. |
+| **CR Gates** | Normative quality checks such as `tests-ci`, `spec-verify`, `security-static`, and `human-approval` enforced on every CR. |
+| **Delivery Lead** | Accountability similar to Scrum Master that steers Delivery Pulse, enforces CR-First, and manages WIP limits. |
+| **Delivery Pulse** | ≤10 minute daily inspection replacing the Daily Scrum, reviewing Pulse Increment evidence and gate status. |
+| **Evidence Bundle** | Audit package (e.g., `requirements-trace.json`, gate logs, Story Preview) linked from each CR. |
+| **Exclusive Lease** | Time-bounded control granting exactly one worker write access to a Story branch during SSP execution. |
+| **Mode Policy** | Guardrail defining when agents may act autonomously, collaborate, or require human approval. |
+| **Pulse Increment** | Daily demo build containing all merged work since the last Pulse, reviewed during Delivery Pulse. |
+| **Sequential Subtask Pipeline (SSP)** | Normative practice sequencing subtasks on a single Story branch with exclusive lease control. |
+| **Story Preview** | Pre-merge demonstration artifact showing acceptance criteria satisfied before Product Owner approval. |
+| **tests-ci** | Required automated verification gate proving code health for each CR. |
+| **spec-verify** | Required gate confirming method conformance, risk controls, and documentation updates per the Specification. |
+| **WIP Limit** | Policy capping concurrent Stories or CRs to preserve flow and prevent gate overload. |

--- a/docs/overview/adoption-guide.md
+++ b/docs/overview/adoption-guide.md
@@ -1,0 +1,29 @@
+# Adoption Guide (Informative)
+
+ADF adoption follows a three-level ladder. Each level builds on Scrum without adding ceremonies. Use the checklists to stage your rollout.
+
+## Level 1 — Foundations
+- Enable the [PR template](../templates/pr-template.md) and Story Preview checklist.
+- Require `tests-ci` and `spec-verify` gates per [Specification §4](../specs/adf-spec-v0.5.0.md#change-request-gates).
+- Schedule a daily Delivery Pulse (≤10 minutes) and nominate a Delivery Lead.
+- Capture Pulse Increment notes in your Evidence Bundle (`requirements-trace.json`).
+
+✅ Completion signal: Product Owner accepts Stories using Story Preview before merge.
+
+## Level 2 — Hardened
+- Add `security-static` and `deps-supply-chain` gates with automated evidence.
+- Run SSP for every Story: sequential subtask execution, exclusive lease, single CR.
+- Track conformance with the [L2 checklist](../templates/conformance-checklist.md) and archive evidence bundles.
+- Extend Delivery Pulse to review guardrail drift and backlog risk.
+
+✅ Completion signal: Every merged CR contains Story Preview, gate evidence, and a linked Evidence Bundle.
+
+## Level 3 — Compliance
+- Enforce remaining gates (`perf-budget`, `framework-guard`, `mode-policy`, `preview-build`, `human-approval`).
+- Implement audit trails using [profiles](../profiles/github.md) or your platform equivalent.
+- Integrate risk reviews into Sprint Review and maintain audit-ready logs in `docs/audits/`.
+- Align with governance requirements defined in the [Handbook Conformance chapter](../handbook/conformance.md).
+
+✅ Completion signal: Independent auditors can replay Delivery Pulse, CR evidence, and compliance decisions from your repository.
+
+Need to tailor per platform? Consult the [Profiles](../profiles/github.md) and [Examples](../examples/github/labels.md) (informative).

--- a/docs/overview/agile-scrum-map.md
+++ b/docs/overview/agile-scrum-map.md
@@ -1,0 +1,21 @@
+# Agile/Scrum Map (Informative)
+
+ADF preserves the Scrum skeleton. Use this alignment to explain the overlay quickly.
+
+| Scrum Element | ADF Alignment | Notes |
+| --- | --- | --- |
+| **Roles** | Product Owner, Delivery Lead (Scrum Master), Developers | Same roles. Delivery Lead enforces CR-First and gate evidence. |
+| **Events** | Sprint Planning, Daily Scrum → Delivery Pulse (≤10 min), Sprint Review, Sprint Retrospective | Daily Scrum becomes Delivery Pulse focused on Pulse Increment evidence and WIP health. No new ceremonies. |
+| **Artifacts** | Product Goal, Product Backlog, Sprint Backlog, Increment → Pulse Increment evidence bundle | Keep existing artifacts; add Story Preview and CR gate evidence per [spec](../specs/adf-spec-v0.5.0.md#change-request-gates). |
+
+### What Stays the Same
+- Timeboxes and Sprint rhythm remain unchanged.
+- Product Owner still accepts work during Story Preview and Sprint Review.
+- Developers self-manage how to meet the Sprint Goal within SSP guardrails.
+
+### What ADF Adds
+- **CR-First** ensures every Increment is reviewable, auditable, and merge-gated.
+- **Story Preview + Evidence Bundle** make acceptance ready before merge.
+- **Pulse Increment** surfaces merged value daily for inspection.
+
+Need detail? Dive into the [Handbook](../handbook/ssp.md) and [CR Gates playbook](../handbook/cr-gates.md).

--- a/docs/overview/quickstart-l1.md
+++ b/docs/overview/quickstart-l1.md
@@ -1,0 +1,25 @@
+# L1 Quickstart (Informative)
+
+Adopt ADF foundations in a single day. Pair this playbook with the [Adoption Guide](adoption-guide.md) and formal rules in the [Specification](../specs/adf-spec-v0.5.0.md).
+
+## Morning — Prepare the Workspace
+- Add the [PR template](../templates/pr-template.md) and Story Preview checklist to your repository.
+- Enable `tests-ci` and `spec-verify` required checks (minimum CR gates for L1).
+- Align the team on SSP basics: one Story branch, serialized subtasks, exclusive lease.
+
+## Midday — Run the First Story
+- Create a Story branch with SSP subtasks sequenced in your issue tracker.
+- Execute each subtask, capturing Story Preview updates and gate evidence in the CR.
+- Use the [Handbook SSP chapter](../handbook/ssp.md) as the operating manual.
+
+## Afternoon — Delivery Pulse + Acceptance
+- Host the first Delivery Pulse (≤10 minutes). Review the Pulse Increment, open CRs, and gate status.
+- Product Owner reviews Story Preview, confirms acceptance, and merges when gates are green.
+- Archive the Evidence Bundle (`requirements-trace.json`) with links to gate outputs.
+
+## Evening — Retrospect and Schedule Next Pulse
+- Capture feedback: Does SSP feel smooth? Are gates visible? Any automation gaps?
+- Schedule the next Delivery Pulse and confirm backlog is ready for the next Sprint day.
+- Update your conformance checklist for L1 completion and plan the L2 hardening items.
+
+From here, continue through L2 and L3 in the [Adoption Guide](adoption-guide.md).

--- a/docs/overview/start-here.md
+++ b/docs/overview/start-here.md
@@ -1,0 +1,18 @@
+# Start Here (Informative)
+
+The Agentic Delivery Framework (ADF) keeps **Scrum as the baseline** while adding agent-aware safety rails. It combines:
+
+- **Change Request (CR)-First flow** so every Increment is governed by a single merge request.
+- **Sequential Subtask Pipeline (SSP)** to serialize human/agent contributions on one Story branch.
+- **Delivery Pulse**: a ≤10 minute daily checkpoint that inspects merged work and quality gates.
+
+ADF is aimed at product teams adopting human+AI delivery. Keep Scrum roles, events, and artifacts; layer ADF evidence and guardrails on top. Normative rules live in the [ADF Specification v0.5.0](../specs/adf-spec-v0.5.0.md) and [Handbook](../handbook/ssp.md).
+
+## How to Use This Site
+
+1. **Map to Scrum**: Review the [Agile/Scrum alignment](agile-scrum-map.md) to see that no new ceremonies are required.
+2. **Adopt in Levels**: Pick your [conformance level](adoption-guide.md) and follow the [L1 Quickstart](quickstart-l1.md).
+3. **Apply the Normative Rules**: Reference the [Specification](../specs/adf-spec-v0.5.0.md) for MUST/SHOULD requirements and the [Handbook](../handbook/ssp.md) for operating detail.
+4. **Use Templates and Profiles**: Start with the [PR template](../templates/pr-template.md) and the [GitHub profile](../profiles/github.md) to implement CR gates.
+
+For deeper study, continue into the normative `/docs/specs` and `/docs/handbook` sections.

--- a/docs/templates/codeowners.example.md
+++ b/docs/templates/codeowners.example.md
@@ -1,0 +1,36 @@
+---
+title: CODEOWNERS Example (Informative)
+---
+
+This page mirrors the [`CODEOWNERS` example](codeowners.example) for quick reference. Copy the raw file when applying to your repository.
+
+```text
+# Example CODEOWNERS for ADF v0.5.0 (documentation only; do not copy verbatim)
+#
+# Purpose: Demonstrates how to enforce human approval (Gate `human-approval`) on risk-tagged paths.
+# Guidance:
+# - Replace `@org/` handles with your teams.
+# - Use labels such as `risk:pci` to align with Story Preview risk notes.
+# - Combine with branch protections described in docs/profiles/github.md.
+
+# Default ownership — require at least one reviewer from core maintainers
+*                                         @org/core-maintainers
+
+# Sensitive database migrations — require data governance sign-off
+# Matches specification rule: human approval MAY be required for risk-tagged paths.
+db/migrations/                            @org/data-governance
+
+# Security-sensitive services — require security architects
+services/auth/**                          @org/security-architects
+
+# Frontend performance budget areas — include performance leads
+web/perf/**                                @org/frontend-perf @org/core-maintainers
+
+# Documentation updates — allow docs guild to review quickly
+docs/**                                    @org/docs-guild
+
+# Break-glass procedure: add Delivery Lead as fallback reviewer
+# When `break-glass` label applied, this reviewer ensures CAPA linkage
+/.github/workflows/**                      @org/delivery-leads
+```
+

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,0 +1,89 @@
+import type {Config} from '@docusaurus/types';
+import type * as Preset from '@docusaurus/preset-classic';
+
+const config: Config = {
+  title: 'Agentic Delivery Framework',
+  tagline: 'Scrum-first, agent-safe delivery',
+  url: 'https://airnub.github.io',
+  baseUrl: '/agentic-delivery-framework/',
+  organizationName: 'airnub',
+  projectName: 'agentic-delivery-framework',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
+  favicon: 'img/favicon.svg',
+  trailingSlash: false,
+  markdown: {
+    mermaid: true,
+  },
+  themes: ['@docusaurus/theme-mermaid'],
+  presets: [
+    [
+      'classic',
+      {
+        docs: {
+          path: '../docs',
+          routeBasePath: '/',
+          sidebarPath: require.resolve('./sidebars.ts'),
+          editUrl: 'https://github.com/airnub/agentic-delivery-framework/edit/work/',
+          showLastUpdateAuthor: true,
+          showLastUpdateTime: true,
+        },
+        blog: false,
+        theme: {
+          customCss: require.resolve('./src/css/custom.css'),
+        },
+      } satisfies Preset.Options,
+    ],
+  ],
+  themeConfig: {
+    navbar: {
+      title: 'ADF',
+      logo: { alt: 'ADF', src: 'img/favicon.svg' },
+      items: [
+        { to: '/overview/start-here', label: 'Start', position: 'left' },
+        { to: '/overview/adoption-guide', label: 'Adopt', position: 'left' },
+        { to: '/specs/adf-spec-v0.5.0', label: 'Spec', position: 'left' },
+        { to: '/handbook/ssp', label: 'Handbook', position: 'left' },
+        { to: '/templates/pr-template', label: 'Templates', position: 'left' },
+        { to: '/profiles/github', label: 'Profiles', position: 'left' },
+        { to: '/audits/README', label: 'Audits', position: 'left' },
+        { to: '/CHANGELOG', label: 'Changelog', position: 'left' },
+        { href: 'https://github.com/airnub/agentic-delivery-framework', label: 'GitHub', position: 'right' },
+      ],
+    },
+    footer: {
+      style: 'dark',
+      links: [
+        {
+          title: 'Learn',
+          items: [
+            { label: 'Start', to: '/overview/start-here' },
+            { label: 'Spec', to: '/specs/adf-spec-v0.5.0' },
+            { label: 'Handbook', to: '/handbook/ssp' },
+          ],
+        },
+        {
+          title: 'Operate',
+          items: [
+            { label: 'Templates', to: '/templates/pr-template' },
+            { label: 'Profiles', to: '/profiles/github' },
+            { label: 'Audits', to: '/audits/README' },
+          ],
+        },
+        {
+          title: 'Community',
+          items: [
+            { label: 'GitHub', href: 'https://github.com/airnub/agentic-delivery-framework' },
+          ],
+        },
+      ],
+      copyright: `© ${new Date().getFullYear()} Agentic Delivery Framework (Informative site).`,
+    },
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/dracula'),
+    },
+  },
+};
+
+export default config;

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -1,0 +1,109 @@
+import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
+
+const sidebars: SidebarsConfig = {
+  overview: [
+    {
+      type: 'category',
+      label: 'Start Here',
+      collapsed: false,
+      items: [
+        'overview/start-here',
+        'overview/agile-scrum-map',
+        'overview/adoption-guide',
+        'overview/quickstart-l1',
+        'faq',
+        'glossary',
+      ],
+    },
+  ],
+
+  spec: [
+    {
+      type: 'category',
+      label: 'Specification',
+      collapsed: false,
+      items: [
+        'specs/adf-spec-v0.5.0',
+        { type: 'link', label: 'v0.4.0 (Historical)', href: '/specs/adf-spec-v0.4.0' },
+      ],
+    },
+  ],
+
+  handbook: [
+    {
+      type: 'category',
+      label: 'Handbook',
+      collapsed: false,
+      items: [
+        'handbook/ssp',
+        'handbook/cr-gates',
+        'handbook/story-preview',
+        'handbook/pulse-increment',
+        'handbook/evidence-bundle',
+        'handbook/metrics',
+        'handbook/conformance',
+        'handbook/safety-rails',
+      ],
+    },
+  ],
+
+  templates: [
+    {
+      type: 'category',
+      label: 'Templates',
+      collapsed: false,
+      items: [
+        'templates/pr-template',
+        'templates/story-preview',
+        'templates/conformance-checklist',
+        'templates/labels',
+        'templates/codeowners.example',
+      ],
+    },
+  ],
+
+  profiles: [
+    {
+      type: 'category',
+      label: 'Profiles (Informative)',
+      collapsed: false,
+      items: [
+        'profiles/github',
+        { type: 'link', label: 'GitLab (stub)', href: '/profiles/gitlab' },
+        { type: 'link', label: 'Azure DevOps (stub)', href: '/profiles/azure' },
+      ],
+    },
+  ],
+
+  examples: [
+    {
+      type: 'category',
+      label: 'Examples (Informative)',
+      collapsed: true,
+      items: [
+        'examples/github/labels',
+        'examples/github/pr-template.example',
+        'examples/github/required-checks.list',
+        'examples/github/repo-settings',
+      ],
+    },
+  ],
+
+  audits: [
+    {
+      type: 'category',
+      label: 'Audits (Informative)',
+      collapsed: true,
+      items: [
+        'audits/README',
+      ],
+    },
+  ],
+
+  root: [
+    { type: 'doc', id: 'README' },
+    { type: 'doc', id: 'CHANGELOG' },
+  ],
+};
+
+export default sidebars;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,0 +1,9 @@
+:root {
+  --ifm-color-primary: #0f7bff;
+  --ifm-color-primary-dark: #0d6ee6;
+  --ifm-color-primary-light: #3f95ff;
+}
+
+.hero .button.button--primary {
+  text-transform: none;
+}

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -1,0 +1,33 @@
+import Link from '@docusaurus/Link';
+import Heading from '@theme/Heading';
+
+# Agentic Delivery Framework
+
+**Scrum simplicity. Agent safety. Auditable delivery.**
+
+This website is an **informative** rendering of ADF. The **normative** source of truth remains in `/docs`.
+
+<div className="container margin-vert--lg">
+  <div className="row">
+    <div className="col col--4">
+      <Heading as="h3">Start Here</Heading>
+      <p>What ADF is, how it maps to Scrum, and how to adopt it with minimal ceremony.</p>
+      <p><Link className="button button--primary" to="/overview/start-here">Start →</Link></p>
+    </div>
+    <div className="col col--4">
+      <Heading as="h3">Adopt in a Day (L1)</Heading>
+      <p>CR-First, Story Preview, tests-ci + spec-verify, and a 10-minute Delivery Pulse.</p>
+      <p><Link className="button button--primary" to="/overview/quickstart-l1">Quickstart →</Link></p>
+    </div>
+    <div className="col col--4">
+      <Heading as="h3">Read the Spec</Heading>
+      <p>Normative rules: CR-First, SSP, CR Gates, Pulse, Evidence, Conformance.</p>
+      <p><Link className="button button--primary" to="/specs/adf-spec-v0.5.0">Spec v0.5.0 →</Link></p>
+    </div>
+  </div>
+</div>
+
+### For Roles
+- **Product Owner:** <Link to="/overview/adoption-guide">Adoption Guide</Link> · <Link to="/handbook/story-preview">Story Preview</Link>
+- **Delivery Lead (Scrum Master):** <Link to="/handbook/cr-gates">CR Gates</Link> · <Link to="/handbook/pulse-increment">Delivery Pulse</Link>
+- **Developers/Agents:** <Link to="/handbook/ssp">SSP</Link> · <Link to="/handbook/safety-rails">Safety Rails</Link>

--- a/website/static/img/favicon.svg
+++ b/website/static/img/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title id="title">ADF Placeholder Icon</title>
+  <rect width="64" height="64" rx="10" fill="#0b3d5c" />
+  <text x="32" y="40" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">ADF</text>
+</svg>


### PR DESCRIPTION
## Summary
- add informative overview, quickstart, FAQ, and glossary docs to support Scrum-first onboarding
- wire docusaurus navbar, sidebars, and landing page to follow the adoption flow
- expose the changelog and CODEOWNERS example through informative doc wrappers for navigation completeness
- replace the binary favicon with an SVG placeholder so the docs site remains binary-free

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e26741e4908324b5ea08ff94dbba7f