### PR TITLE
docs: add Kanban onboarding lenses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,6 @@
 ## 10. Canonical Examples
 - Use `requirements-trace.json` when referencing the example Evidence Bundle requirements filename.
 - Do not introduce alternative example filenames for the same artifact; treat non-canonical names as legacy references to replace.
+
+## 11. Guidance
+- **Kanban visualization:** You MAY present SSP via a minimal Kanban board as an informative lens. Do **not** remove the Story Lease, introduce parallel WIP, or add a second backlog.

--- a/docs/handbook/ssp.md
+++ b/docs/handbook/ssp.md
@@ -89,3 +89,21 @@ Automation **MAY** enforce WIP limits by blocking Step 2 when another executor h
 - **Reviewer unavailable:** Use the `mode-policy` gate to enforce fallback CODEOWNERS or escalate to the Delivery Lead.
 
 For detailed gate remediation steps, consult the [CR Gates guide](cr-gates.md).
+
+## Kanban Lens (informative)
+
+Teams MAY visualize the Sequential Subtask Pipeline (SSP) with a minimal Kanban board to aid transparency and flow control. This lens introduces **no new ceremonies** and **no new backlogs**; SSP’s normative rules (Story Lease, WIP=1 per Story, ordered subtask queue, single CR, CR Gates) remain unchanged.
+
+```mermaid
+flowchart LR
+  R[Ready (ordered)] --> IP[In Progress (leased, WIP=1)] --> CG[Checkpoint Green] --> G[CR Gates] --> D[Done]
+```
+
+**Explicit policies (lens)**
+
+* **Pull:** Take the topmost **Ready** subtask for the current Story; if the Story Lease is held, wait.
+* **WIP:** **WIP=1** per Story; no parallel subtasks.
+* **Blocked:** Mark with a reason and aging; escalate if aging exceeds your SLE.
+* **Replenish:** PO/Delivery Lead may reorder **Ready** between subtasks (not mid-subtask); document the reason in the Story.
+* **Expedite:** Use break-glass only with approval; auto-file CAPA; flag in the Delivery Pulse.
+* **Done:** A subtask is Done when merged via the Story’s CR and **CR Gates** are green.

--- a/docs/overview/for-kanban-teams.md
+++ b/docs/overview/for-kanban-teams.md
@@ -1,0 +1,34 @@
+# ADF for Kanban Teams (informative)
+
+ADF’s **Sequential Subtask Pipeline (SSP)** behaves like **single‑piece flow**:
+- Pull the **next subtask** in order; **WIP=1** per Story is enforced via the **Story Lease**.
+- Reach a local **Checkpoint Green**, then push.
+- Merge via a single **Change Request**; **CR Gates** (tests, security, perf, policy) decide.
+
+## Minimal board (lens)
+```mermaid
+flowchart LR
+  R[Ready (ordered)] --> IP[In Progress (leased, WIP=1)] --> CG[Checkpoint Green] --> G[CR Gates] --> D[Done]
+```
+
+**Explicit policies (lens)**
+
+* **Pull:** Take top **Ready**; respect the Lease.
+* **WIP:** One subtask at a time.
+* **Blocked:** Mark reason + aging; escalate if SLE breached.
+* **Replenish:** Leads may reorder between subtasks (not mid-subtask); document reason in the Story.
+* **Expedite:** Break-glass with approval; CAPA; Pulse flag.
+* **Done:** Subtask Done when merged (gates green).
+
+## Minimal metrics (helpful, not mandatory)
+
+* Subtask **cycle time** (Ready → Done)
+* Story **lead time** (first subtask start → merge)
+* **Blocked aging** (time in Blocked)
+
+## Where to go next
+
+* **SSP (normative rules)** → `../handbook/ssp.md`
+* **CR Gates (portable checks)** → `../handbook/cr-gates.md`
+* **Delivery Pulse (inspectability)** → `../handbook/pulse-increment.md`
+

--- a/docs/overview/for-scrum-teams.md
+++ b/docs/overview/for-scrum-teams.md
@@ -1,0 +1,27 @@
+# ADF for Scrum Teams (informative)
+
+**What changes?** Almost nothing. ADF is **Scrum + 3 invisible automations**:
+1) **CR‑First** — Every change merges via a Change Request with a **Story Preview** and **CR Gates**.
+2) **SSP (Sequential Subtask Pipeline)** — A small sequencing policy: one Story branch, exclusive **Story Lease**, ordered subtasks, single CR.
+3) **Delivery Pulse** — A daily, ≤10‑minute look at a demoable artifact (the **Pulse Increment**) to keep progress inspectable.
+
+## Scrum mapping (roles, events, artifacts)
+- **Roles** — Product Owner; **Delivery Lead** (Scrum Master equivalent + authority over gates/lease); Developers (human + agent).
+- **Events** — Sprint Planning, **Daily** (review the Pulse ≤10 min), Sprint Review, Sprint Retrospective.
+- **Artifacts** — Product Backlog, Sprint Backlog, Increment. *Augments:* **Story Preview**, **Pulse Increment**.
+
+## Adopt ADF in a Day (L1 Quickstart)
+- Use the **PR template** with Story Preview → `../templates/pr-template.md`
+- Require **`tests-ci`** and **`spec-verify`** gates.
+- Enforce **CR‑First** merges (no direct pushes to `main`).
+- Produce one **Delivery Pulse** artifact per day and glance at it in the daily.
+
+## What stays the same
+- Sprint cadence, Sprint Goal, PO acceptance, team ownership.
+- No new ceremonies; the Pulse is not a meeting, just a 10‑minute artifact review.
+
+## Where to go next
+- **Spec v0.5.0** → `../specs/adf-spec-v0.5.0.md`
+- **SSP (how the work flows)** → `../handbook/ssp.md`
+- **CR Gates (what must be green)** → `../handbook/cr-gates.md`
+- **Delivery Pulse** → `../handbook/pulse-increment.md`

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -11,6 +11,8 @@ const sidebars: SidebarsConfig = {
         'overview/agile-scrum-map',
         'overview/adoption-guide',
         'overview/quickstart-l1',
+        'overview/for-scrum-teams',
+        'overview/for-kanban-teams',
         'faq',
         'glossary',
       ],

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -13,6 +13,11 @@ This website is an **informative** rendering of ADF. The **normative** source of
       <Heading as="h3">Start Here</Heading>
       <p>What ADF is, how it maps to Scrum, and how to adopt it with minimal ceremony.</p>
       <p><Link className="button button--primary" to="/overview/start-here">Start →</Link></p>
+      <p>
+        <Link to="/overview/for-scrum-teams">For Scrum Teams →</Link>
+        &nbsp;·&nbsp;
+        <Link to="/overview/for-kanban-teams">For Kanban Teams →</Link>
+      </p>
     </div>
     <div className="col col--4">
       <Heading as="h3">Adopt in a Day (L1)</Heading>


### PR DESCRIPTION
## Summary
- add a Kanban Lens (informative) subsection to the SSP handbook entry
- add informative onboarding one-pagers for Scrum and Kanban teams
- update AGENTS guidance and Docusaurus navigation to surface the new pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2702b6e208324bc7cfce01c5fba6f